### PR TITLE
Update library version to D2.6.8 and upgrade mysql connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>rentasad.library</groupId>
     <artifactId>rentasad.library.db</artifactId>
-    <version>D2.6.7</version>
+    <version>D2.6.8</version>
 
     <name>rentasad.library.db</name>
     <!-- FIXME change it to the project's website -->

--- a/rentasad.library.db.ads/pom.xml
+++ b/rentasad.library.db.ads/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>rentasad.library.db</artifactId>
 		<groupId>rentasad.library</groupId>
-		<version>D2.6.7</version>
+		<version>D2.6.8</version>
 	</parent>
 	<groupId>rentasad</groupId>
 	<artifactId>rentasad.library.db.ads</artifactId>

--- a/rentasad.library.db.ads2mysqlTransfer/pom.xml
+++ b/rentasad.library.db.ads2mysqlTransfer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>rentasad.library.db</artifactId>
 		<groupId>rentasad.library</groupId>
-		<version>D2.6.7</version>
+		<version>D2.6.8</version>
 	</parent>
 	<groupId>rentasad</groupId>
 	<artifactId>rentasad.library.db.ads2mysqlTransfer</artifactId>

--- a/rentasad.library.db.mssql/pom.xml
+++ b/rentasad.library.db.mssql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>rentasad.library.db</artifactId>
 		<groupId>rentasad.library</groupId>
-		<version>D2.6.7</version>
+		<version>D2.6.8</version>
 	</parent>
 	<groupId>rentasad</groupId>
 	<artifactId>rentasad.library.db.mssql</artifactId>

--- a/rentasad.library.db.mysql/pom.xml
+++ b/rentasad.library.db.mysql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>rentasad.library.db</artifactId>
 		<groupId>rentasad.library</groupId>
-		<version>D2.6.7</version>
+		<version>D2.6.8</version>
 	</parent>
 	<groupId>rentasad</groupId>
 	<artifactId>rentasad.library.db.mysql</artifactId>
@@ -30,13 +30,14 @@
 			<artifactId>rentasad.library.basicTools.stringTools</artifactId>
 			<version>${basicToolParentVersion}</version>
 		</dependency>
-		<!-- UPDATE 20.09.2018 Update nach Fehler in ServerTimeZone -> Fallback 
-			zu alter Version https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+		<!-- Update to new Connector
+		https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.33</version>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>8.4.0</version>
 		</dependency>
+
 	</dependencies>
 	<build>
 		<pluginManagement><!-- lock down plugins versions to avoid using Maven 

--- a/rentasad.library.db.sqlExecutionTool/pom.xml
+++ b/rentasad.library.db.sqlExecutionTool/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>rentasad.library.db</artifactId>
         <groupId>rentasad.library</groupId>
-        <version>D2.6.7</version>
+        <version>D2.6.8</version>
     </parent>
     <groupId>rentasad</groupId>
     <artifactId>rentasad.library.db.sqlExecutionTool</artifactId>

--- a/updateVersion.cmd
+++ b/updateVersion.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-call mvn versions:set -DnewVersion=D2.6.7
+call mvn versions:set -DnewVersion=D2.6.8
 
 ::If you made a mistake, do
 :: mvn versions:revert


### PR DESCRIPTION
The library version has been updated to D2.6.8 in all modules. Additionally, the mysql connector dependency version has been upgraded more recent version.